### PR TITLE
Add NIH PI email permutation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # NIH-Test-2
+
+This repository contains a helper script for extracting principal investigator (PI) information from NIH project JSON files and generating common academic email permutations.
+
+## Usage
+
+1. Install requirements (pandas is needed):
+   ```bash
+   pip install pandas
+   ```
+2. Run the script with a path to the JSON file:
+   ```bash
+   python generate_pi_emails.py path/to/response.json --output nih_pi_emails.csv
+   ```
+   The output CSV will include the PI name, institution, project title, project detail URL, and generated email permutations.
+
+The script also includes a placeholder function for future email validation integrations (e.g., using Hunter API or SMTP checks).

--- a/generate_pi_emails.py
+++ b/generate_pi_emails.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import pandas as pd
+import re
+from pathlib import Path
+
+
+def create_domain(institution: str) -> str:
+    """Convert institution name to a simple email domain."""
+    cleaned = re.sub(r"[^a-zA-Z0-9]", "", institution).lower()
+    return f"{cleaned}.edu" if cleaned else "example.edu"
+
+
+def generate_email_permutations(first_name: str, last_name: str, domain: str) -> list[str]:
+    """Return common academic email permutations."""
+    first = first_name.lower()
+    last = last_name.lower()
+    initial = first[0] if first else ""
+    return [
+        f"{first}.{last}@{domain}",
+        f"{initial}{last}@{domain}",
+        f"{initial}.{last}@{domain}",
+    ]
+
+
+def placeholder_validate_email(email: str) -> bool:
+    """Placeholder for future email validation."""
+    # TODO: integrate with Hunter API or SMTP check
+    return True
+
+
+def main(json_path: Path, output_csv: Path):
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    rows = []
+    projects = data if isinstance(data, list) else data.get("results", [])
+    for project in projects:
+        title = project.get("projectTitle", "")
+        url = project.get("projectDetailUrl", "")
+        org = project.get("organization", {}).get("org_name", "")
+        domain = create_domain(org)
+        for pi in project.get("principalInvestigators", []):
+            full_name = pi.get("fullName", "")
+            first = pi.get("first_name", "")
+            last = pi.get("last_name", "")
+            emails = generate_email_permutations(first, last, domain)
+            for email in emails:
+                rows.append({
+                    "Full Name": full_name,
+                    "Institution": org,
+                    "Project Title": title,
+                    "Project Detail URL": url,
+                    "Email": email,
+                })
+
+    df = pd.DataFrame(rows)
+    df.to_csv(output_csv, index=False)
+    print(f"Saved {len(df)} email permutations to {output_csv}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate PI email permutations from NIH JSON data")
+    parser.add_argument("json_file", type=Path, help="Path to NIH JSON file")
+    parser.add_argument("--output", type=Path, default=Path("nih_pi_emails.csv"), help="CSV output path")
+    args = parser.parse_args()
+    main(args.json_file, args.output)


### PR DESCRIPTION
## Summary
- add `generate_pi_emails.py` to read NIH JSON project files and create email permutations
- document usage in README

## Testing
- `python -m py_compile generate_pi_emails.py`
- `python generate_pi_emails.py sample.json --output test_emails.csv`

------
https://chatgpt.com/codex/tasks/task_e_68509007ec64833393b6ed1b9e3a4c4c